### PR TITLE
Use qualified key name instead of key name

### DIFF
--- a/src/Services/Iterator.php
+++ b/src/Services/Iterator.php
@@ -22,7 +22,7 @@ class Iterator
         $this->query = $this->exporter->query()
             ->select($this->exporter->attributes());
 
-        $this->primaryKey = $this->query->getModel()->getKeyName();
+        $this->primaryKey = $this->query->getModel()->getQualifiedKeyName();
     }
 
     public function valid(): bool


### PR DESCRIPTION
By using key name I have the problem that I get an "<key_name> is ambiguous" error on more complex queries

`->getKeyName()` returns `<key>`
`->getQualifiedKeyName()` returns `<table>.<key>`